### PR TITLE
Fix reading symbols of .smx compiled with version 0x0101

### DIFF
--- a/smxdasm/Headers.cs
+++ b/smxdasm/Headers.cs
@@ -188,7 +188,7 @@ namespace smxdasm
                 entry.Name = header.string_at(entry.nameoffs);
 
                 // Remember that there's a .dbg.natives section in the file. 
-                if(entry.Name == ".dbg.natives")
+                if (entry.Name == ".dbg.natives")
                     foundDbgNativesSection = true;
 
                 header.Sections[i] = entry;

--- a/smxdasm/Sections.cs
+++ b/smxdasm/Sections.cs
@@ -485,7 +485,7 @@ namespace smxdasm
         public SmxDebugSymbolsTable(FileHeader file, SectionEntry header, SmxDebugInfoSection info, SmxNameTable names)
             : base(file, header)
         {
-            entries_ = DebugSymbolEntry.From(file.SectionReader(header), info, names, file.debugUnpacked);
+            entries_ = DebugSymbolEntry.From(file, file.SectionReader(header), info, names);
         }
 
         private void buildDatRefs()

--- a/smxdasm/V1Types.cs
+++ b/smxdasm/V1Types.cs
@@ -316,7 +316,7 @@ namespace smxdasm
         public string Name;
         public DebugSymbolDimEntry[] Dims;
 
-        public static DebugSymbolEntry[] From(BinaryReader rd, SmxDebugInfoSection info, SmxNameTable names, bool debugUnpacked)
+        public static DebugSymbolEntry[] From(FileHeader hdr, BinaryReader rd, SmxDebugInfoSection info, SmxNameTable names)
         {
             var entries = new DebugSymbolEntry[info.NumSymbols];
             for (var i = 0; i < info.NumSymbols; i++)
@@ -325,7 +325,7 @@ namespace smxdasm
                 entry.Address = rd.ReadInt32();
                 entry.TagId = rd.ReadUInt16();
                 // There's a padding of 2 bytes after this short.
-                if (debugUnpacked)
+                if (hdr.debugUnpacked)
                     rd.ReadBytes(2);
                 entry.CodeStart = rd.ReadUInt32();
                 entry.CodeEnd = rd.ReadUInt32();
@@ -335,7 +335,7 @@ namespace smxdasm
                 entry.nameoffs = rd.ReadInt32();
                 entry.Name = names.StringAt(entry.nameoffs);
                 if (entry.dimcount > 0)
-                    entry.Dims = DebugSymbolDimEntry.From(rd, entry.dimcount, debugUnpacked);
+                    entry.Dims = DebugSymbolDimEntry.From(hdr, rd, entry.dimcount);
                 entries[i] = entry;
             }
             return entries;
@@ -348,14 +348,14 @@ namespace smxdasm
         public ushort tagid;        // Tag id (unmasked).
         public int Size;           // Size of the dimension.
 
-        public static DebugSymbolDimEntry[] From(BinaryReader rd, int count, bool debugUnpacked)
+        public static DebugSymbolDimEntry[] From(FileHeader hdr, BinaryReader rd, int count)
         {
             var entries = new DebugSymbolDimEntry[count];
             for (var i = 0; i < count; i++)
             {
                 var entry = new DebugSymbolDimEntry();
                 // There's a padding of 2 bytes before this short.
-                if (debugUnpacked)
+                if (hdr != null && hdr.debugUnpacked)
                     rd.ReadBytes(2);
                 entry.tagid = rd.ReadUInt16();
                 entry.Size = rd.ReadInt32();
@@ -432,7 +432,7 @@ namespace smxdasm
                 entry.dimcount = rd.ReadUInt16();
                 entry.nameoffs = rd.ReadInt32();
                 if (entry.dimcount > 0)
-                    entry.Dims = DebugSymbolDimEntry.From(rd, entry.dimcount, false);
+                    entry.Dims = DebugSymbolDimEntry.From(null, rd, entry.dimcount);
                 entry.Name = names.StringAt(entry.nameoffs);
                 entries[i] = entry;
             }


### PR DESCRIPTION
Plugins compiled using compiler codeversion 0x0101 have their symbol
structs padded/unpacked.

Account for this padding correctly.
