### PR TITLE
Collect unknown functions while disassembling

### DIFF
--- a/smxdasm/Sections.cs
+++ b/smxdasm/Sections.cs
@@ -142,6 +142,39 @@ namespace smxdasm
         }
     }
 
+    public class SmxCalledFunctionsTable
+    {
+        private List<CalledFunctionEntry> functions_;
+
+        public SmxCalledFunctionsTable()
+        {
+            functions_ = new List<CalledFunctionEntry>();
+        }
+
+        public CalledFunctionEntry[] Entries
+        {
+            get { return functions_.ToArray(); }
+        }
+
+        public int Length
+        {
+            get { return functions_.Count; }
+        }
+
+        public CalledFunctionEntry this[int index]
+        {
+            get { return functions_[index]; }
+        }
+
+        public void AddFunction(uint addr)
+        {
+            var entry = new CalledFunctionEntry();
+            entry.Address = addr;
+            entry.Name = String.Format("sub_{0:x}", addr);
+            functions_.Add(entry);
+        }
+    }
+
     // The .pubvars table.
     public class SmxPubvarTable : SmxSection
     {

--- a/smxdasm/V1Disassembler.cs
+++ b/smxdasm/V1Disassembler.cs
@@ -180,6 +180,7 @@ namespace smxdasm
             Prep(V1Opcode.ZERO_S, V1Param.Stack);
         }
 
+        private SmxFile file_;
         private byte[] data_;
         private int code_start_;
         private int proc_offset_;
@@ -205,6 +206,7 @@ namespace smxdasm
 
         private V1Disassembler(SmxFile file, SmxCodeV1Section code, int proc_offset)
         {
+            file_ = file;
             data_ = file.Header.Data;
             code_start_ = code.CodeStart;
             proc_offset_ = proc_offset;
@@ -247,6 +249,14 @@ namespace smxdasm
                 insn.Params = new int[insn.Info.Params.Length];
                 for (var i = 0; i < insn.Info.Params.Length; i++)
                     insn.Params[i] = readNext();
+
+                // Catch calls to unknown functions so they can be disassembled easily too.
+                if (op == (int)V1Opcode.CALL)
+                {
+                    var addr = insn.Params[0];
+                    if (file_.FindFunctionName(addr) == "(unknown)")
+                        file_.CalledFunctions.AddFunction((uint)addr);
+                }
             }
             return insns.ToArray();
         }

--- a/smxdasm/V1Types.cs
+++ b/smxdasm/V1Types.cs
@@ -103,6 +103,13 @@ namespace smxdasm
         }
     }
 
+    // Called functions that weren't in the .publics or .dbg.symbols sections.
+    public class CalledFunctionEntry
+    {
+        public uint Address;
+        public string Name;
+    }
+
     // The ".natives" section.
     public class NativeEntry
     {

--- a/smxviewer/MainWindow.cs
+++ b/smxviewer/MainWindow.cs
@@ -499,6 +499,13 @@ namespace smxviewer
                     functionMap[sym.Name] = sym.CodeStart;
                 }
             }
+            if (file_.CalledFunctions != null)
+            {
+                foreach (var fun in file_.CalledFunctions.Entries)
+                {
+                    functionMap[fun.Name] = fun.Address;
+                }
+            }
 
             foreach (var pair in functionMap)
             {


### PR DESCRIPTION
When encountering a `call` while disassembling check if there is an entry for the called address in the ".publics" or ".dbg.symbols" sections. If the function is missing add it to a seperate list to be able to disassemble functions even while debug info is stripped.

The functions are added with a name like `sub_<addr>` to be unqiue.