### PR TITLE
Fix typos in symbol lookups

### DIFF
--- a/smxdasm/Sections.cs
+++ b/smxdasm/Sections.cs
@@ -516,7 +516,7 @@ namespace smxdasm
             {
                 if (entry.Ident != SymKind.Function)
                     continue;
-                if (address >= entry.Address && address <= entry.Address)
+                if (address >= entry.CodeStart && address <= entry.CodeEnd)
                     return entry;
             }
             return null;
@@ -556,7 +556,7 @@ namespace smxdasm
                 if (i == symbols.Count - 1)
                     break;
 
-                var next_sym = symbols[i];
+                var next_sym = symbols[i + 1];
 
                 // Only arrays can be accessed out of their starting address.
                 if (sym.Ident != SymKind.Array)
@@ -586,7 +586,7 @@ namespace smxdasm
                 if (sym.Ident != SymKind.Array)
                     continue;
 
-                var next_sym = dat_refs_[i];
+                var next_sym = dat_refs_[i + 1];
                 if (address > sym.Address && address < next_sym.Address)
                     return sym;
             }


### PR DESCRIPTION
Functions were searched by their exact address instead of their whole code range.

Stackrefs and datrefs looking for arrays had a typo when checking the beginning of the next symbol.